### PR TITLE
Add cursor pointer on tag hover

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -108,7 +108,7 @@
                 <!-- FILTERS -->
                 <div class="flex flex-row flex-wrap justify-center gap-1 overflow-scroll no-scrollbar pt-8">
                     {#each TAGS as tag}
-                        <div class="pr-0 py-1
+                        <div class="pr-0 py-1 cursor-pointer
                             md:pr-2 md:py-1
                         ">
                             <!-- svelte-ignore a11y-click-events-have-key-events -->


### PR DESCRIPTION
This PR introduces a UI enhancement where the cursor changes to a pointer when hovering over a specific tag. This provides a more intuitive user experience, indicating that the tag is clickable. The change was implemented in the `page.svelte` file.